### PR TITLE
feat: enhance time entry response with additional fields and add tags tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
 import { findProjectTool } from "./tools/projects";
 import { getCurrentUserTool } from "./tools/users";
 import { findWorkspacesTool } from "./tools/workspaces";
+import { getTagsTool } from "./tools/tags";
 import { z } from "zod";
 import { argv } from "process";
 
@@ -72,6 +73,13 @@ export default function createStatelessServer({
     editEntryTool.description,
     editEntryTool.parameters,
     editEntryTool.handler
+  );
+
+  server.tool(
+    getTagsTool.name,
+    getTagsTool.description,
+    getTagsTool.parameters,
+    getTagsTool.handler
   );
   return server.server;
 }

--- a/src/tools/entries.ts
+++ b/src/tools/entries.ts
@@ -89,6 +89,14 @@ export const listEntriesTool: McpToolConfig = {
         duration: entry.duration,
         start: entry.start,
         end: entry.end,
+        projectId: entry.projectId,
+        projectName: entry.project?.name,
+        taskId: entry.taskId,
+        taskName: entry.task?.name,
+        tags: entry.tags?.map((tag: any) => tag.name) || [],
+        tagIds: entry.tagIds || [],
+        timeInterval: entry.timeInterval,
+        billable: entry.billable,
       }));
 
       return {

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -1,0 +1,34 @@
+import { api } from "../config/api";
+import { z } from "zod";
+import { McpResponse, McpToolConfig } from "../types";
+
+export const getTagsTool: McpToolConfig = {
+  name: "get-tags",
+  description: "Get all tags in a workspace",
+  parameters: {
+    workspaceId: z
+      .string()
+      .describe("The ID of the workspace to get tags from"),
+  },
+  handler: async ({ workspaceId }: { workspaceId: string }): Promise<McpResponse> => {
+    if (!workspaceId || typeof workspaceId !== "string") {
+      throw new Error("Workspace ID required to fetch tags");
+    }
+
+    const response = await api.get(`workspaces/${workspaceId}/tags`);
+    const tags = response.data.map((tag: any) => ({
+      id: tag.id,
+      name: tag.name,
+      workspaceId: tag.workspaceId,
+    }));
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(tags),
+        },
+      ],
+    };
+  },
+};


### PR DESCRIPTION
## Summary
This PR enhances the Clockify MCP server with the following improvements:

- **Enhanced time entry list response**: Added `projectName`, `taskId`, `taskName`, `tags`, `tagIds`, `timeInterval`, and `billable` fields to the list-time-entries tool response
- **New get-tags tool**: Added a new tool to retrieve all tags in a workspace, making it easier to understand and categorize time entries

## Changes
1. Modified `src/tools/entries.ts` to include additional fields in the `listEntriesTool` response
2. Created new `src/tools/tags.ts` file with `getTagsTool` implementation
3. Updated `src/index.ts` to register the new get-tags tool

## Benefits
- Users can now see project and task names directly in time entry listings
- Tags/categories are now visible in the response
- New tool provides easy access to all workspace tags for reference
- Billing status is now included in the response

These enhancements make it much easier to understand and analyze time entries without needing to make additional API calls or manually lookup IDs.