### PR TITLE
feat: add taskId, tagIds to time entries + list-tasks tool + fix edit

### DIFF
--- a/src/clockify-sdk/entries.ts
+++ b/src/clockify-sdk/entries.ts
@@ -10,12 +10,14 @@ import { URLSearchParams } from "node:url";
 
 function EntriesService(api: AxiosInstance) {
   async function create(entry: TCreateEntrySchema) {
-    const body = {
-      ...entry,
-      workspaceId: undefined,
-    };
+    const { workspaceId, ...rest } = entry;
 
-    return api.post(`workspaces/${entry.workspaceId}/time-entries`, body);
+    // Filter out undefined values to avoid sending nulls to Clockify
+    const body = Object.fromEntries(
+      Object.entries(rest).filter(([_, value]) => value !== undefined)
+    );
+
+    return api.post(`workspaces/${workspaceId}/time-entries`, body);
   }
 
   async function find(filters: TFindEntrySchema) {
@@ -45,14 +47,15 @@ function EntriesService(api: AxiosInstance) {
   }
 
   async function update(params: TEditEntrySchema) {
-    const body = {
-      ...params,
-      workspaceId: undefined,
-      timeEntryId: undefined,
-    };
+    const { workspaceId, timeEntryId, ...rest } = params;
+
+    // Filter out undefined values to avoid sending nulls to Clockify
+    const body = Object.fromEntries(
+      Object.entries(rest).filter(([_, value]) => value !== undefined)
+    );
 
     return api.put(
-      `workspaces/${params.workspaceId}/time-entries/${params.timeEntryId}`,
+      `workspaces/${workspaceId}/time-entries/${timeEntryId}`,
       body
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { findProjectTool } from "./tools/projects";
 import { getCurrentUserTool } from "./tools/users";
 import { findWorkspacesTool } from "./tools/workspaces";
 import { getTagsTool } from "./tools/tags";
+import { listTasksTool } from "./tools/tasks";
 import { z } from "zod";
 import { argv } from "process";
 
@@ -80,6 +81,13 @@ export default function createStatelessServer({
     getTagsTool.description,
     getTagsTool.parameters,
     getTagsTool.handler
+  );
+
+  server.tool(
+    listTasksTool.name,
+    listTasksTool.description,
+    listTasksTool.parameters,
+    listTasksTool.handler
   );
   return server.server;
 }

--- a/src/tools/entries.ts
+++ b/src/tools/entries.ts
@@ -178,17 +178,23 @@ export const editEntryTool: McpToolConfig = {
   },
   handler: async (params: TEditEntrySchema): Promise<McpResponse> => {
     try {
-      let start = params.start;
-      if (!start) {
-        const current = await entriesService.getById(
-          params.workspaceId,
-          params.timeEntryId
-        );
-        start = new Date(current.data.timeInterval.start);
-      }
+      // Fetch current entry to get required fields that weren't provided
+      const current = await entriesService.getById(
+        params.workspaceId,
+        params.timeEntryId
+      );
+
+      // Merge current values with provided params (params take precedence)
       const result = await entriesService.update({
-        ...params,
-        start,
+        workspaceId: params.workspaceId,
+        timeEntryId: params.timeEntryId,
+        start: params.start ?? new Date(current.data.timeInterval.start),
+        end: params.end ?? new Date(current.data.timeInterval.end),
+        billable: params.billable ?? current.data.billable,
+        description: params.description ?? current.data.description,
+        projectId: params.projectId ?? current.data.projectId,
+        taskId: params.taskId ?? current.data.taskId,
+        tagIds: params.tagIds ?? current.data.tagIds,
       });
 
       const entryInfo = `Time entry updated successfully. ID: ${result.data.id} Name: ${result.data.description}`;

--- a/src/tools/entries.ts
+++ b/src/tools/entries.ts
@@ -29,6 +29,14 @@ export const createEntryTool: McpToolConfig = {
       .string()
       .optional()
       .describe("The id of the project associated with this time entry"),
+    taskId: z
+      .string()
+      .optional()
+      .describe("The id of the task (activity) within the project to associate with this time entry"),
+    tagIds: z
+      .array(z.string())
+      .optional()
+      .describe("Array of tag IDs to associate with this time entry"),
   },
   handler: async (params: TCreateEntrySchema): Promise<McpResponse> => {
     try {
@@ -159,6 +167,14 @@ export const editEntryTool: McpToolConfig = {
       .string()
       .optional()
       .describe("The id of the project associated with this time entry"),
+    taskId: z
+      .string()
+      .optional()
+      .describe("The id of the task (activity) within the project to associate with this time entry"),
+    tagIds: z
+      .array(z.string())
+      .optional()
+      .describe("Array of tag IDs to associate with this time entry"),
   },
   handler: async (params: TEditEntrySchema): Promise<McpResponse> => {
     try {

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1,0 +1,42 @@
+import { api } from "../config/api";
+import { z } from "zod";
+import { McpResponse, McpToolConfig } from "../types";
+
+export const listTasksTool: McpToolConfig = {
+  name: "list-tasks",
+  description: "List tasks (activities) within a project. Tasks can be associated with time entries.",
+  parameters: {
+    workspaceId: z
+      .string()
+      .describe("The ID of the workspace"),
+    projectId: z
+      .string()
+      .describe("The ID of the project to get tasks from"),
+  },
+  handler: async ({ workspaceId, projectId }: { workspaceId: string; projectId: string }): Promise<McpResponse> => {
+    if (!workspaceId || typeof workspaceId !== "string") {
+      throw new Error("Workspace ID required to fetch tasks");
+    }
+    if (!projectId || typeof projectId !== "string") {
+      throw new Error("Project ID required to fetch tasks");
+    }
+
+    const response = await api.get(`workspaces/${workspaceId}/projects/${projectId}/tasks`);
+    const tasks = response.data.map((task: any) => ({
+      id: task.id,
+      name: task.name,
+      projectId: task.projectId,
+      status: task.status,
+      assigneeIds: task.assigneeIds,
+    }));
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(tasks),
+        },
+      ],
+    };
+  },
+};

--- a/src/validation/entries/create-entry-schema.ts
+++ b/src/validation/entries/create-entry-schema.ts
@@ -7,4 +7,6 @@ export const CreateEntrySchema = z.object({
   start: z.coerce.date(),
   end: z.coerce.date(),
   projectId: z.string().optional(),
+  taskId: z.string().optional(),
+  tagIds: z.array(z.string()).optional(),
 });

--- a/src/validation/entries/edit-entry-schema.ts
+++ b/src/validation/entries/edit-entry-schema.ts
@@ -8,4 +8,6 @@ export const EditEntrySchema = z.object({
   start: z.union([z.coerce.date(), z.undefined()]).optional(),
   end: z.union([z.coerce.date(), z.undefined()]).optional(),
   projectId: z.string().optional(),
+  taskId: z.string().optional(),
+  tagIds: z.array(z.string()).optional(),
 });


### PR DESCRIPTION
## Summary

- Add `taskId` and `tagIds` parameters to create and edit time entry operations
- Add new `list-tasks` tool to discover tasks (activities) within a project
- Fix edit-time-entry failing with 400 errors

## Motivation

Currently there's no way to:
1. Associate time entries with specific tasks or tags without knowing the IDs
2. Discover task IDs without going to the Clockify UI

## Changes

### New features
- `src/validation/entries/create-entry-schema.ts` - Added `taskId` and `tagIds`
- `src/validation/entries/edit-entry-schema.ts` - Added `taskId` and `tagIds`
- `src/tools/entries.ts` - Added parameters with descriptions to create/edit tools
- `src/tools/tasks.ts` - New `list-tasks` tool
- `src/index.ts` - Registered the new tool

### Bug fixes
- `src/clockify-sdk/entries.ts` - Fixed create/update sending `null` values by filtering undefined
- `src/tools/entries.ts` - Fixed edit handler to fetch and merge all required fields (start, end, billable, projectId) from current entry

## Test plan

- [x] Create time entry with `taskId` parameter
- [x] Create time entry with `tagIds` parameter  
- [x] Edit time entry changing only description (was failing with 400)
- [x] Use `list-tasks` tool to retrieve tasks from a project
- [x] Verify backwards compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)