### PR TITLE
feat: add create-tag tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
 import { findProjectTool } from "./tools/projects";
 import { getCurrentUserTool } from "./tools/users";
 import { findWorkspacesTool } from "./tools/workspaces";
-import { getTagsTool } from "./tools/tags";
+import { createTagTool, getTagsTool } from "./tools/tags";
 import { listTasksTool } from "./tools/tasks";
 import { z } from "zod";
 import { argv } from "process";
@@ -81,6 +81,13 @@ export default function createStatelessServer({
     getTagsTool.description,
     getTagsTool.parameters,
     getTagsTool.handler
+  );
+
+  server.tool(
+    createTagTool.name,
+    createTagTool.description,
+    createTagTool.parameters,
+    createTagTool.handler
   );
 
   server.tool(

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -2,6 +2,37 @@ import { api } from "../config/api";
 import { z } from "zod";
 import { McpResponse, McpToolConfig } from "../types";
 
+export const createTagTool: McpToolConfig = {
+  name: "create-tag",
+  description: "Create a new tag in a workspace",
+  parameters: {
+    workspaceId: z
+      .string()
+      .describe("The ID of the workspace to create the tag in"),
+    name: z.string().describe("The name of the tag to create"),
+  },
+  handler: async ({
+    workspaceId,
+    name,
+  }: {
+    workspaceId: string;
+    name: string;
+  }): Promise<McpResponse> => {
+    const response = await api.post(`workspaces/${workspaceId}/tags`, {
+      name,
+    });
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Tag created successfully. ID: ${response.data.id} Name: ${response.data.name}`,
+        },
+      ],
+    };
+  },
+};
+
 export const getTagsTool: McpToolConfig = {
   name: "get-tags",
   description: "Get all tags in a workspace",


### PR DESCRIPTION
## Summary

- Add new `create-tag` tool for creating tags in a Clockify workspace

## Motivation

Currently there's no way to create new tags via the MCP server — users have to go to the Clockify UI to create tags before they can associate them with time entries.

## Changes

### New features
- `src/tools/tags.ts` - New `createTagTool` that POSTs to `/workspaces/{workspaceId}/tags`
- `src/index.ts` - Imported and registered the new tool

## Test plan

- [ ] Create a tag with a name in a workspace
- [ ] Verify the created tag ID and name are returned
- [ ] Verify backwards compatibility with existing `get-tags` tool