### PR TITLE
fix: add pagination to all list endpoints

### DIFF
--- a/src/clockify-sdk/entries.ts
+++ b/src/clockify-sdk/entries.ts
@@ -7,6 +7,7 @@ import {
   TEditEntrySchema,
 } from "../types";
 import { URLSearchParams } from "node:url";
+import { fetchAllPages } from "../config/pagination";
 
 function EntriesService(api: AxiosInstance) {
   async function create(entry: TCreateEntrySchema) {
@@ -33,11 +34,12 @@ function EntriesService(api: AxiosInstance) {
 
     if (filters.project) searchParams.append("project", filters.project);
 
-    return api.get(
-      `https://api.clockify.me/api/v1/workspaces/${filters.workspaceId}/user/${
-        filters.userId
-      }/time-entries?${searchParams.toString()}`
+    const data = await fetchAllPages<any>(
+      `workspaces/${filters.workspaceId}/user/${filters.userId}/time-entries`,
+      searchParams
     );
+
+    return { data };
   }
 
   async function deleteEntry(params: TDeleteEntrySchema) {

--- a/src/clockify-sdk/projects.ts
+++ b/src/clockify-sdk/projects.ts
@@ -1,9 +1,15 @@
 import { AxiosInstance } from "axios";
 import { api } from "../config/api";
+import { fetchAllPages } from "../config/pagination";
 
 function ProjectsService(api: AxiosInstance) {
   async function fetchAll(workspaceId: string) {
-    return api.get(`workspaces/${workspaceId}/projects?archived=false`);
+    const params = new URLSearchParams({ archived: "false" });
+    const data = await fetchAllPages<any>(
+      `workspaces/${workspaceId}/projects`,
+      params
+    );
+    return { data };
   }
 
   return { fetchAll };

--- a/src/config/pagination.ts
+++ b/src/config/pagination.ts
@@ -1,0 +1,27 @@
+import { AxiosInstance } from "axios";
+import { api } from "./api";
+
+const PAGE_SIZE = 200;
+
+export async function fetchAllPages<T>(
+  url: string,
+  params?: URLSearchParams,
+  client: AxiosInstance = api
+): Promise<T[]> {
+  const searchParams = params ?? new URLSearchParams();
+  const allItems: T[] = [];
+  let page = 1;
+
+  while (true) {
+    searchParams.set("page", String(page));
+    searchParams.set("page-size", String(PAGE_SIZE));
+
+    const response = await client.get(`${url}?${searchParams.toString()}`);
+
+    allItems.push(...response.data);
+    if (response.data.length < PAGE_SIZE) break;
+    page++;
+  }
+
+  return allItems;
+}

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -1,4 +1,5 @@
 import { api } from "../config/api";
+import { fetchAllPages } from "../config/pagination";
 import { z } from "zod";
 import { McpResponse, McpToolConfig } from "../types";
 
@@ -15,8 +16,8 @@ export const getTagsTool: McpToolConfig = {
       throw new Error("Workspace ID required to fetch tags");
     }
 
-    const response = await api.get(`workspaces/${workspaceId}/tags`);
-    const tags = response.data.map((tag: any) => ({
+    const data = await fetchAllPages<any>(`workspaces/${workspaceId}/tags`);
+    const tags = data.map((tag) => ({
       id: tag.id,
       name: tag.name,
       workspaceId: tag.workspaceId,

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1,4 +1,4 @@
-import { api } from "../config/api";
+import { fetchAllPages } from "../config/pagination";
 import { z } from "zod";
 import { McpResponse, McpToolConfig } from "../types";
 
@@ -21,8 +21,8 @@ export const listTasksTool: McpToolConfig = {
       throw new Error("Project ID required to fetch tasks");
     }
 
-    const response = await api.get(`workspaces/${workspaceId}/projects/${projectId}/tasks`);
-    const tasks = response.data.map((task: any) => ({
+    const data = await fetchAllPages<any>(`workspaces/${workspaceId}/projects/${projectId}/tasks`);
+    const tasks = data.map((task: any) => ({
       id: task.id,
       name: task.name,
       projectId: task.projectId,

--- a/test/pagination.test.ts
+++ b/test/pagination.test.ts
@@ -1,0 +1,69 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { AxiosInstance } from "axios";
+import { fetchAllPages } from "../src/config/pagination";
+
+function createMockClient(pages: any[][]): AxiosInstance {
+  let callCount = 0;
+  return {
+    get: async () => {
+      const data = pages[callCount++] ?? [];
+      return { data };
+    },
+  } as unknown as AxiosInstance;
+}
+
+describe("fetchAllPages", () => {
+  it("returns all items from a single page", async () => {
+    const client = createMockClient([[{ id: "1" }, { id: "2" }]]);
+
+    const result = await fetchAllPages<{ id: string }>(
+      "workspaces/123/tags",
+      undefined,
+      client
+    );
+
+    assert.strictEqual(result.length, 2);
+    assert.deepStrictEqual(result, [{ id: "1" }, { id: "2" }]);
+  });
+
+  it("fetches multiple pages until last page has fewer items", async () => {
+    const page1 = Array.from({ length: 200 }, (_, i) => ({ id: String(i) }));
+    const page2 = [{ id: "200" }, { id: "201" }];
+    const client = createMockClient([page1, page2]);
+
+    const result = await fetchAllPages<{ id: string }>(
+      "workspaces/123/tags",
+      undefined,
+      client
+    );
+
+    assert.strictEqual(result.length, 202);
+  });
+
+  it("returns empty array when API returns no items", async () => {
+    const client = createMockClient([[]]);
+
+    const result = await fetchAllPages("workspaces/123/tags", undefined, client);
+
+    assert.strictEqual(result.length, 0);
+  });
+
+  it("passes extra params alongside pagination params", async () => {
+    let capturedUrl = "";
+    const client = {
+      get: async (url: string) => {
+        capturedUrl = url;
+        return { data: [] };
+      },
+    } as unknown as AxiosInstance;
+
+    const params = new URLSearchParams({ archived: "false" });
+    await fetchAllPages("workspaces/123/projects", params, client);
+
+    assert(capturedUrl.includes("archived=false"), "should include archived param");
+    assert(capturedUrl.includes("page=1"), "should include page param");
+    assert(capturedUrl.includes("page-size=200"), "should include page-size param");
+    assert(!capturedUrl.includes("?&"), "should not have ?& in URL");
+  });
+});


### PR DESCRIPTION
## Summary

- Add shared `fetchAllPages` helper that paginates through all results from Clockify API
- Apply pagination to all list endpoints: tags, time entries, projects, tasks

## Motivation

All list endpoints were hitting the Clockify API default limit of 50 items, silently dropping anything beyond that.

## Changes

### New
- `src/config/pagination.ts` - Shared `fetchAllPages<T>(url, params?, client?)` that loops through pages of 200 until a page returns fewer items
- `test/pagination.test.ts` - Unit tests for the pagination helper

### Modified
- `src/tools/tags.ts` - `get-tags` uses `fetchAllPages`
- `src/clockify-sdk/entries.ts` - `find` uses `fetchAllPages`
- `src/clockify-sdk/projects.ts` - `fetchAll` uses `fetchAllPages`
- `src/tools/tasks.ts` - `list-tasks` uses `fetchAllPages`

## Test plan

- [x] Unit tests for `fetchAllPages` (single page, multi page, empty, extra params)
- [x] Manual verification with workspace that has >50 tags
- [x] Manual verification with >50 time entries