### PR TITLE
feat: add create-task tool for creating project tasks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { findProjectTool } from "./tools/projects";
 import { getCurrentUserTool } from "./tools/users";
 import { findWorkspacesTool } from "./tools/workspaces";
 import { createTagTool, getTagsTool } from "./tools/tags";
-import { listTasksTool } from "./tools/tasks";
+import { createTaskTool, listTasksTool } from "./tools/tasks";
 import { z } from "zod";
 import { argv } from "process";
 
@@ -95,6 +95,13 @@ export default function createStatelessServer({
     listTasksTool.description,
     listTasksTool.parameters,
     listTasksTool.handler
+  );
+
+  server.tool(
+    createTaskTool.name,
+    createTaskTool.description,
+    createTaskTool.parameters,
+    createTaskTool.handler
   );
   return server.server;
 }

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1,6 +1,72 @@
+import { api } from "../config/api";
 import { fetchAllPages } from "../config/pagination";
 import { z } from "zod";
 import { McpResponse, McpToolConfig } from "../types";
+
+export const createTaskTool: McpToolConfig = {
+  name: "create-task",
+  description:
+    "Create a new task (activity) within a project. The created task can be associated with time entries.",
+  parameters: {
+    workspaceId: z
+      .string()
+      .describe("The ID of the workspace that contains the project"),
+    projectId: z
+      .string()
+      .describe("The ID of the project to create the task in"),
+    name: z.string().describe("The name of the task to create"),
+    assigneeIds: z
+      .array(z.string())
+      .optional()
+      .describe("Optional array of user IDs to assign to the task"),
+    status: z
+      .enum(["ACTIVE", "DONE"])
+      .optional()
+      .describe("Optional status of the task (defaults to ACTIVE)"),
+  },
+  handler: async ({
+    workspaceId,
+    projectId,
+    name,
+    assigneeIds,
+    status,
+  }: {
+    workspaceId: string;
+    projectId: string;
+    name: string;
+    assigneeIds?: string[];
+    status?: "ACTIVE" | "DONE";
+  }): Promise<McpResponse> => {
+    if (!workspaceId || typeof workspaceId !== "string") {
+      throw new Error("Workspace ID required to create a task");
+    }
+    if (!projectId || typeof projectId !== "string") {
+      throw new Error("Project ID required to create a task");
+    }
+    if (!name || typeof name !== "string") {
+      throw new Error("Task name required to create a task");
+    }
+
+    const response = await api.post(
+      `workspaces/${workspaceId}/projects/${projectId}/tasks`,
+      {
+        name,
+        ...(assigneeIds ? { assigneeIds } : {}),
+        ...(status ? { status } : {}),
+      }
+    );
+
+    const task = response.data;
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Task created successfully. ID: ${task.id} Name: ${task.name} Status: ${task.status}`,
+        },
+      ],
+    };
+  },
+};
 
 export const listTasksTool: McpToolConfig = {
   name: "list-tasks",


### PR DESCRIPTION
## Summary

Adds a `create-task` tool that creates a new task (activity) within a project. Created tasks can then be associated with time entries (complementing the existing `list-tasks` tool).

## Details

- New `createTaskTool` in `src/tools/tasks.ts`, registered in `src/index.ts`.
- Parameters: `workspaceId`, `projectId`, `name` (required); `assigneeIds` and `status` (`ACTIVE`/`DONE`) optional.
- POSTs to `workspaces/{workspaceId}/projects/{projectId}/tasks`, mirroring the existing `create-tag` tool's structure and validation.

## Testing

- `tsc --noEmit` passes.
- Verified the server boots and responds to an MCP `initialize` handshake with the new tool registered.