### PR TITLE
feat: add update-task and delete-task tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { findProjectTool } from "./tools/projects";
 import { getCurrentUserTool } from "./tools/users";
 import { findWorkspacesTool } from "./tools/workspaces";
 import { createTagTool, getTagsTool } from "./tools/tags";
-import { createTaskTool, listTasksTool } from "./tools/tasks";
+import { createTaskTool, updateTaskTool, deleteTaskTool, listTasksTool } from "./tools/tasks";
 import { getHoursByClientTool } from "./tools/reports";
 import { z } from "zod";
 import { argv } from "process";
@@ -103,6 +103,20 @@ export default function createStatelessServer({
     createTaskTool.description,
     createTaskTool.parameters,
     createTaskTool.handler
+  );
+
+  server.tool(
+    updateTaskTool.name,
+    updateTaskTool.description,
+    updateTaskTool.parameters,
+    updateTaskTool.handler
+  );
+
+  server.tool(
+    deleteTaskTool.name,
+    deleteTaskTool.description,
+    deleteTaskTool.parameters,
+    deleteTaskTool.handler
   );
 
   server.tool(

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -68,6 +68,149 @@ export const createTaskTool: McpToolConfig = {
   },
 };
 
+export const updateTaskTool: McpToolConfig = {
+  name: "update-task",
+  description:
+    "Update a task (activity) in a project: rename it, change its status (ACTIVE/DONE), and/or reassign it. Clockify's PUT requires a name, so if you omit `name` the task's current name is fetched and preserved (lets you mark DONE or reassign without renaming).",
+  parameters: {
+    workspaceId: z
+      .string()
+      .describe("The ID of the workspace that contains the project"),
+    projectId: z
+      .string()
+      .describe("The ID of the project that contains the task"),
+    taskId: z.string().describe("The ID of the task to update"),
+    name: z
+      .string()
+      .optional()
+      .describe("New task name (rename). If omitted, the existing name is preserved."),
+    status: z
+      .enum(["ACTIVE", "DONE"])
+      .optional()
+      .describe("New status for the task"),
+    assigneeIds: z
+      .array(z.string())
+      .optional()
+      .describe("Replacement array of assignee user IDs"),
+  },
+  handler: async ({
+    workspaceId,
+    projectId,
+    taskId,
+    name,
+    status,
+    assigneeIds,
+  }: {
+    workspaceId: string;
+    projectId: string;
+    taskId: string;
+    name?: string;
+    status?: "ACTIVE" | "DONE";
+    assigneeIds?: string[];
+  }): Promise<McpResponse> => {
+    if (!workspaceId || typeof workspaceId !== "string") {
+      throw new Error("Workspace ID required to update a task");
+    }
+    if (!projectId || typeof projectId !== "string") {
+      throw new Error("Project ID required to update a task");
+    }
+    if (!taskId || typeof taskId !== "string") {
+      throw new Error("Task ID required to update a task");
+    }
+    if (name === undefined && status === undefined && assigneeIds === undefined) {
+      throw new Error(
+        "Provide at least one of name, status, or assigneeIds to update"
+      );
+    }
+
+    const path = `workspaces/${workspaceId}/projects/${projectId}/tasks/${taskId}`;
+
+    // Clockify's PUT is a full replace and requires a name; preserve the
+    // current one when the caller only wants to change status/assignees.
+    let taskName = name;
+    if (taskName === undefined) {
+      const got = await api.get(path);
+      taskName = got.data?.name;
+    }
+
+    const response = await api.put(path, {
+      name: taskName,
+      ...(status ? { status } : {}),
+      ...(assigneeIds ? { assigneeIds } : {}),
+    });
+
+    const task = response.data;
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Task updated successfully. ID: ${task.id} Name: ${task.name} Status: ${task.status}`,
+        },
+      ],
+    };
+  },
+};
+
+export const deleteTaskTool: McpToolConfig = {
+  name: "delete-task",
+  description:
+    "Permanently delete a task (activity) from a project. Requires an admin API token — Clockify returns 403 for non-admins regardless of the task's status. To close a task without deleting it, use update-task with status DONE.",
+  parameters: {
+    workspaceId: z
+      .string()
+      .describe("The ID of the workspace that contains the project"),
+    projectId: z
+      .string()
+      .describe("The ID of the project that contains the task"),
+    taskId: z.string().describe("The ID of the task to delete"),
+  },
+  handler: async ({
+    workspaceId,
+    projectId,
+    taskId,
+  }: {
+    workspaceId: string;
+    projectId: string;
+    taskId: string;
+  }): Promise<McpResponse> => {
+    if (!workspaceId || typeof workspaceId !== "string") {
+      throw new Error("Workspace ID required to delete a task");
+    }
+    if (!projectId || typeof projectId !== "string") {
+      throw new Error("Project ID required to delete a task");
+    }
+    if (!taskId || typeof taskId !== "string") {
+      throw new Error("Task ID required to delete a task");
+    }
+
+    try {
+      await api.delete(
+        `workspaces/${workspaceId}/projects/${projectId}/tasks/${taskId}`
+      );
+    } catch (err: any) {
+      if (err?.response?.status === 403) {
+        // The task is left untouched — surface an actionable message so the
+        // caller knows deletion is admin-only (not a task-status problem).
+        throw new Error(
+          "Delete failed: this Clockify token lacks admin permission to delete tasks " +
+            "(Clockify 403). The task was NOT deleted. To close it instead, use update-task " +
+            "with status DONE, or have a workspace admin delete it in the Clockify UI."
+        );
+      }
+      throw err;
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Task deleted successfully. ID: ${taskId}`,
+        },
+      ],
+    };
+  },
+};
+
 export const listTasksTool: McpToolConfig = {
   name: "list-tasks",
   description: "List tasks (activities) within a project. Tasks can be associated with time entries.",


### PR DESCRIPTION
Closes #14.

Completes task (activity) CRUD alongside the existing `create-task` / `list-tasks`.

### Changes
- **`update-task`** — `PUT /workspaces/{ws}/projects/{proj}/tasks/{id}`. Rename a task, change status (`ACTIVE`/`DONE`), and/or reassign. Clockify's PUT is a full replace and requires a `name`, so when `name` is omitted the current one is fetched and preserved — allowing status- or assignee-only updates.
- **`delete-task`** — `DELETE /workspaces/{ws}/projects/{proj}/tasks/{id}`. Pure delete, no side effects. Deletion requires an **admin** API token; for non-admin tokens Clockify returns 403 regardless of task status, so the handler catches it and returns an actionable message pointing to `update-task` (status `DONE`) as the non-destructive alternative. The task is left untouched on failure.

Both follow the existing tool structure in `src/tools/tasks.ts` and are registered in `src/index.ts`.

### Notes
- No new dependencies.
- `tsc --noEmit` passes clean.
- Validated against the live Clockify API: create/rename/mark-DONE via `update-task` return 200; `delete-task` returns the friendly 403 message on a non-admin token as expected.